### PR TITLE
binder files

### DIFF
--- a/binder/postBuild
+++ b/binder/postBuild
@@ -1,0 +1,1 @@
+jupyter labextension install nbgather

--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -1,0 +1,3 @@
+numpy
+scikit-learn
+matplotlib


### PR DESCRIPTION
Hey @andrewhead 👋 

this PR adds some minimal files that will allow this repository to be built with BinderHub (we run a public BinderHub at mybinder.org). It adds a folder that define two configuration files Binder can use to determine the environment needed to run the repository.

It'll let you share Binder links so that others can interact with the code inside. For example, here's the Binder link to **my branch**:

https://mybinder.org/v2/gh/choldgraf/gather/binder?urlpath=lab

Try creating a Jupyter Notebook and you should see the Gather interface on there!

If you like this, we should merge another PR that adds a demo notebook people can use to try out Gather!