### PR TITLE
Ensure parser returns empty program when parsing comments

### DIFF
--- a/src/analysis/parse/python/python3.jison
+++ b/src/analysis/parse/python/python3.jison
@@ -198,7 +198,9 @@ expressions
 // file_input: (NEWLINE | stmt)* ENDMARKER
 file_input
     : EOF
-    | file_input0 EOF    { $$ = { type: 'module', code: $1, location: @$ } }
+        { $$ = { type: 'module', code: [], location: @$ } }
+    | file_input0 EOF
+        { $$ = { type: 'module', code: $1, location: @$ } }
     ;
 
 file_input0

--- a/src/analysis/slice/program-builder.ts
+++ b/src/analysis/slice/program-builder.ts
@@ -63,17 +63,6 @@ export class CellProgram {
   readonly hasError: boolean;
 }
 
-function isComment(code: string) {
-  const multiLine = code.split('\n');
-  for (let line of multiLine) {
-      // Once we find a line that isn't a comment, return false
-      if (!line.startsWith('#')) {
-          return false;
-      }
-  }
-  return true;
-}
-
 /**
  * Builds programs from a list of executed cells.
  */
@@ -98,13 +87,8 @@ export class ProgramBuilder {
       let uses: Ref[] = undefined;
       let hasError = cell.hasError;
       try {
-        const code = `${this._magicsRewriter.rewrite(cell.text)}\n`;
-        // If the rewritten code is just a comment, do not attempt parse
-        // The resultant tree will be an empty string and tree.code === undefined
-        if (isComment(code)) { break; }
-
         // Parse the cell's code.
-        let tree = ast.parse(code);
+        let tree = ast.parse(this._magicsRewriter.rewrite(cell.text) + '\n');
         statements = tree.code;
         // Annotate each node with cell ID info, for dataflow caching.
         for (let node of ast.walk(tree)) {

--- a/src/test/parser.test.ts
+++ b/src/test/parser.test.ts
@@ -12,6 +12,12 @@ describe('python parser', () => {
     parse('obj.prop\n');
   });
 
+  it('can parse comments', () => {
+    const tree = parse('#\n');
+    expect(tree.code).to.be.an('array');
+    expect(tree.code.length).to.equal(0);
+  });
+
   it('can parse scientific notation', () => {
     parse('1e5\n');
   });


### PR DESCRIPTION
When `cell.text` is a comment-only string, or when rewriting magics results in a comment-only string, `ast.parse()` returns an empty string:
https://github.com/microsoft/gather/blob/0ad10fd2c4ecd01dc4857c8e779b6c01ded2e00f/src/analysis/slice/program-builder.ts#L90-L92

`ProgramBuilder.add()`then throws a TypeError when we try to walk the tree:
```
Couldn't analyze block <comment-only code> , error encountered,  TypeError: tree.code is not iterable
```
And in `python-parser.ts`, `walkRecursive` logs the following error to the console:
```
Node undefined. Ancestors:
```
This doesn't crash the extension because it's surrounded with a try/catch, but I'm submitting a PR for this because it pollutes logs whenever we execute magics-only or comment-only cells otherwise.