### PR TITLE
Bugfix: correct getTextSlice slicing logic

### DIFF
--- a/src/model/cellslice.ts
+++ b/src/model/cellslice.ts
@@ -38,6 +38,11 @@ export class CellSlice {
           .map((line, index0) => {
             let index = index0 + 1;
             let left, right;
+            // If a dedent has caused last_line to be +1 more than it should be,
+            // and we're actually out of bounds for this node, return early
+            if (loc.last_column === 0 && index > loc.last_line - 1) {
+              return '';
+            }
             if (index == loc.first_line) {
               left = loc.first_column;
             }

--- a/src/test/cellslice.test.ts
+++ b/src/test/cellslice.test.ts
@@ -18,6 +18,19 @@ describe('CellSlice', () => {
     expect(cellSlice.textSlice).to.equal(['a = 1', '2', 'c = '].join('\n'));
   });
 
+  it('correctly yields a text slice based on a set of locations for a funcdef', () => {
+    let cellSlice = new CellSlice(
+      new LogCell({
+        text: ['def foo():', '    pass', 'a = 1', 'foo()', ''].join('\n'),
+        executionCount: 1,
+      }),
+      new LocationSet(
+        { first_line: 1, first_column: 0, last_line: 3, last_column: 0 },
+      )
+    );
+    expect(cellSlice.textSliceLines).to.equal(['def foo():', '    pass'].join('\n'));
+  });
+
   it('yields entire lines if requested', () => {
     let cellSlice = new CellSlice(
       new LogCell({

--- a/src/test/cellslice.test.ts
+++ b/src/test/cellslice.test.ts
@@ -24,11 +24,16 @@ describe('CellSlice', () => {
         text: ['def foo():', '    pass', 'a = 1', 'foo()', ''].join('\n'),
         executionCount: 1,
       }),
-      new LocationSet(
-        { first_line: 1, first_column: 0, last_line: 3, last_column: 0 },
-      )
+      new LocationSet({
+        first_line: 1,
+        first_column: 0,
+        last_line: 3,
+        last_column: 0,
+      })
     );
-    expect(cellSlice.textSliceLines).to.equal(['def foo():', '    pass'].join('\n'));
+    expect(cellSlice.textSliceLines).to.equal(
+      ['def foo():', '    pass'].join('\n')
+    );
   });
 
   it('yields entire lines if requested', () => {

--- a/src/test/slice.test.ts
+++ b/src/test/slice.test.ts
@@ -21,7 +21,7 @@ describe('slices', () => {
       last_column: 5,
     });
   });
-  
+
   it('at least yields the statement for a seed', () => {
     let ast = parse(['c = 1', ''].join('\n'));
     let locations = slice(
@@ -43,14 +43,3 @@ describe('slices', () => {
     ).to.be.true;
   });
 });
-
-function log(locations: LocationSet) {
-  locations.items.map(loc => {
-    console.log(
-      `first_line: ${loc.first_line}`,
-      `first_column: ${loc.first_column}`,
-      `last_line: ${loc.last_line}`,
-      `last_column: ${loc.last_column}`,
-    )
-  })
-}

--- a/src/test/slice.test.ts
+++ b/src/test/slice.test.ts
@@ -21,61 +21,7 @@ describe('slices', () => {
       last_column: 5,
     });
   });
-
-  it('statements including the def and use for funcdefs', () => {
-    let ast = parse([
-      'def foo():',
-      '    print("hi")',
-      'a = 1',
-      'foo()',
-      ''
-    ].join('\n'));
-    let locations = slice(
-      ast,
-      new LocationSet({
-        first_line: 4, 
-        first_column: 0,
-        last_line: 4,
-        last_column: 5
-      })
-    );
-
-    // Expect locations.items to contain the location for def foo()
-    expect(locations.items).to.deep.include({
-      first_line: 1,
-      first_column: 0,
-      last_line: 2, // Instead this is 3
-      last_column: 15 // Instead this is 0
-    });
-  })
-
-  it('statements including the def and use for class defs', () => {
-    let ast = parse([
-      'class Foo():',
-      '    pass',
-      'a = 1',
-      'Foo()',
-      ''
-    ].join('\n'));
-    let locations = slice(
-      ast,
-      new LocationSet({
-        first_line: 4, 
-        first_column: 0,
-        last_line: 4,
-        last_column: 5
-      })
-    );
-
-    // Expect locations.items to contain the location for class Foo
-    expect(locations.items).to.deep.include({
-      first_line: 1,
-      first_column: 0,
-      last_line: 2, // Instead this is 3
-      last_column: 8 // Instead this is 0
-    })
-  })
-
+  
   it('at least yields the statement for a seed', () => {
     let ast = parse(['c = 1', ''].join('\n'));
     let locations = slice(

--- a/src/test/slice.test.ts
+++ b/src/test/slice.test.ts
@@ -22,6 +22,60 @@ describe('slices', () => {
     });
   });
 
+  it('statements including the def and use for funcdefs', () => {
+    let ast = parse([
+      'def foo():',
+      '    print("hi")',
+      'a = 1',
+      'foo()',
+      ''
+    ].join('\n'));
+    let locations = slice(
+      ast,
+      new LocationSet({
+        first_line: 4, 
+        first_column: 0,
+        last_line: 4,
+        last_column: 5
+      })
+    );
+
+    // Expect locations.items to contain the location for def foo()
+    expect(locations.items).to.deep.include({
+      first_line: 1,
+      first_column: 0,
+      last_line: 2, // Instead this is 3
+      last_column: 15 // Instead this is 0
+    });
+  })
+
+  it('statements including the def and use for class defs', () => {
+    let ast = parse([
+      'class Foo():',
+      '    pass',
+      'a = 1',
+      'Foo()',
+      ''
+    ].join('\n'));
+    let locations = slice(
+      ast,
+      new LocationSet({
+        first_line: 4, 
+        first_column: 0,
+        last_line: 4,
+        last_column: 5
+      })
+    );
+
+    // Expect locations.items to contain the location for class Foo
+    expect(locations.items).to.deep.include({
+      first_line: 1,
+      first_column: 0,
+      last_line: 2, // Instead this is 3
+      last_column: 8 // Instead this is 0
+    })
+  })
+
   it('at least yields the statement for a seed', () => {
     let ast = parse(['c = 1', ''].join('\n'));
     let locations = slice(
@@ -43,3 +97,14 @@ describe('slices', () => {
     ).to.be.true;
   });
 });
+
+function log(locations: LocationSet) {
+  locations.items.map(loc => {
+    console.log(
+      `first_line: ${loc.first_line}`,
+      `first_column: ${loc.first_column}`,
+      `last_line: ${loc.last_line}`,
+      `last_column: ${loc.last_column}`,
+    )
+  })
+}


### PR DESCRIPTION
For #31 

With this fix, CellSlice.textSliceLines does not include duplicate lines of code after the end of a funcdef or classdef. Depending on whether it's semantically accurate to modify the location object that is returned by the parser, we might want to fix this issue at the parser level instead? @andrewhead 

- [x] Regression tests pass
- [x] Ran `jlpm run format:all`
- [x] Added unit test for functionality change