### PR TITLE
Fix icons not appearing in version browser

### DIFF
--- a/src/widgets/revision/widget.ts
+++ b/src/widgets/revision/widget.ts
@@ -84,14 +84,14 @@ export class Revision extends Widget {
     panelLayout.addWidget(
       this.createButton(
         'Open in notebook',
-        'jp-BookIcon',
+        'jp-Toolbar-gatherbutton-BookIcon',
         GatherState.GATHER_TO_NOTEBOOK
       )
     );
     panelLayout.addWidget(
       this.createButton(
         'Copy to clipboard',
-        'jp-CellsIcon',
+        'jp-Toolbar-gatherbutton-CellsIcon',
         GatherState.GATHER_TO_CLIPBOARD
       )
     );


### PR DESCRIPTION
Replaced the icon names with the new ones and tested them. icons are now visible in version browser.